### PR TITLE
removed internal or local setting /home/y/lib in QMAKE_RPATH

### DIFF
--- a/src/phantomjs.pro
+++ b/src/phantomjs.pro
@@ -3,8 +3,6 @@ TARGET = phantomjs
 QT += network webkit
 CONFIG += console
 
-QMAKE_RPATHDIR = /home/y/lib
-
 DESTDIR = ../bin
 
 RESOURCES = phantomjs.qrc \


### PR DESCRIPTION
/home/y/lib must be an internal or developers' specific local setting - users normally would not have such a directory, therefore suggesting to delete the unnecessary setting.

Partial link command on Ubuntu 13.10 with the current setting:
make[1]: Entering directory `[...]/tpjs/src'
g++ -Wl,-O1 -Wl,-rpath,/home/y/lib -o ../bin/phantomjs phantom.o callback.o webpage.o [...]
